### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,7 @@ sphinx:
 
 formats: all
 
-python:
-   version: 3.9
-
 build:
-  image: testing
+   os: ubuntu-20.04
+   tools:
+      python: "3.9"


### PR DESCRIPTION
python3.9が正式にサポートされるようになったので、readthedocsの設定を変更しました。